### PR TITLE
Add private chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ run:
 pip3 install -r requirements.txt
 python3 app.py
 ```
+
+Private chats are available via `/private/<username>` or by visiting the direct
+link `/p/<id>`.

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,5 +17,27 @@
       </div>
     </div>
   </form>
+
+  <h2 class="mt-5">Private Chats</h2>
+  <ul class="list-group">
+    {% for room in private_rooms %}
+      {% if room.user1 == current_user %}
+        {% set other = room.user2 %}
+      {% else %}
+        {% set other = room.user1 %}
+      {% endif %}
+      <li class="list-group-item">
+        <a href="{{ url_for('private_by_id', room_id=room.id) }}">{{ other.username }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+  <form class="mt-4" method="get" action="{{ url_for('redir_private') }}">
+    <div class="input-group">
+      <input name="username" class="form-control" placeholder="Enter username" required>
+      <div class="input-group-append">
+        <button class="btn btn-secondary" type="submit">Start Private Chat</button>
+      </div>
+    </div>
+  </form>
 </div>
 {% endblock %}

--- a/templates/private.html
+++ b/templates/private.html
@@ -1,0 +1,36 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h3>Chat with {{ other.username }}</h3>
+  <div class="chat-box border p-3 mt-3" style="height: 300px; overflow-y: scroll;" id="chat"></div>
+  <form onsubmit="sendMessage(); return false;" class="mt-2">
+    <div class="input-group">
+      <input id="message" class="form-control" placeholder="Type a message...">
+      <div class="input-group-append">
+        <button class="btn btn-primary">Send</button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+<script>
+  const socket = io();
+  const room = 'private_{{ room.id }}';
+  socket.emit('join', { room: room });
+
+  socket.on('message', data => {
+    document.getElementById('chat').innerHTML += `<div>${data.msg}</div>`;
+  });
+
+  socket.on('status', data => {
+    document.getElementById('chat').innerHTML += `<div><em>${data.msg}</em></div>`;
+  });
+
+  function sendMessage() {
+    const msg = document.getElementById('message').value;
+    socket.emit('message', { room: room, msg: msg });
+    document.getElementById('message').value = '';
+  }
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `PrivateRoom` model
- allow chat access via `/private/<username>` and `/p/<id>`
- list private chats on the home page
- add `templates/private.html`
- document private chat URLs in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687277f309708321b6e0c20c0ca98841